### PR TITLE
Make EnergyPlus executable configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ This project contains a minimal FastAPI backend used to run EnergyPlus simulatio
 ## Prerequisites
 
 - **Python 3.10** (the OpenStudio bindings were built for this version)
-- **EnergyPlus** installed and available as `/usr/local/bin/energyplus`. This typically
-  comes from the [OpenStudio](https://github.com/NREL/OpenStudio/releases) or
-  [EnergyPlus](https://energyplus.net/download) distributions. Make sure the
-  executable is on your `PATH` or create a symlink to `/usr/local/bin/energyplus`.
+* **EnergyPlus** installed. By default the backend expects the executable at
+  `/usr/local/bin/energyplus` (as provided by the
+  [OpenStudio](https://github.com/NREL/OpenStudio/releases) or
+  [EnergyPlus](https://energyplus.net/download) distributions). You can override
+  this location using the `ENERGYPLUS_PATH` environment variable.
 - **OpenStudio Python bindings** – installed via `pip install openstudio` (see
   `backend/requirements.txt`).
 

--- a/backend/app/runner.py
+++ b/backend/app/runner.py
@@ -1,16 +1,25 @@
+import os
 import subprocess
 import logging
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-def run_simulation(idf_path: str, tmp_dir: str, weather_path: str) -> str:
+def run_simulation(
+    idf_path: str,
+    tmp_dir: str,
+    weather_path: str,
+    energyplus_path: str | None = None,
+) -> str:
     try:
+        exe = energyplus_path or os.getenv("ENERGYPLUS_PATH", "/usr/local/bin/energyplus")
+
         version_result = subprocess.run(
-            ["/usr/local/bin/energyplus", "--version"],
+            [exe, "--version"],
             capture_output=True,
             text=True
         )
+        logger.info(f"Using EnergyPlus executable: {exe}")
         logger.info(f"EnergyPlus version: {version_result.stdout.strip()}")
 
         for path in [idf_path, weather_path]:
@@ -20,7 +29,7 @@ def run_simulation(idf_path: str, tmp_dir: str, weather_path: str) -> str:
         Path(tmp_dir).mkdir(parents=True, exist_ok=True)
 
         cmd = [
-            "/usr/local/bin/energyplus",
+            exe,
             "-w", str(weather_path),
             "-d", str(tmp_dir),
             "-r",


### PR DESCRIPTION
## Summary
- allow setting EnergyPlus path via `ENERGYPLUS_PATH` env var or function arg
- document the new environment variable

## Testing
- `python -m py_compile backend/app/main.py backend/app/model_builder.py backend/app/runner.py`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68407c1e15448320a03ec6da2405e9a9